### PR TITLE
v0.6.1 | Fix react-error-overlay bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,18 +42,20 @@
         "eslint-import-resolver-typescript": "^2.4.0",
         "pre-commit": "^1.2.2",
         "prettier": "^2.5.1",
+        "react-error-overlay": "6.0.9",
         "react-scripts": "4.0.3",
         "sass": "^1.39.2",
         "typescript": "^4.4.3"
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -3368,10 +3370,32 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
       "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -4164,9 +4188,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.0.tgz",
-      "integrity": "sha512-r8aveDbd+rzGP+ykSdF3oPuTVRWRfbBiHl0rVDM2yNEmSMXfkObQLV46b4RnCv3Lra51OlfnZhkkFaDl2MIRaA==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -4303,9 +4327,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.49.tgz",
-      "integrity": "sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==",
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -7340,9 +7364,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.2.tgz",
-      "integrity": "sha512-Z5I2vzDnEIqO2YhELVMFcL1An2CIsFe9Q7byZhs8c/QxummxZlAHw33TUHbIte987LkisOgL0LwQ1P9D6VISnA==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.3.tgz",
+      "integrity": "sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -7351,12 +7375,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-      "integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+      "integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.20.3",
         "semver": "7.0.0"
       },
       "funding": {
@@ -7374,9 +7398,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.2.tgz",
-      "integrity": "sha512-Lb+/XT4WC4PaCWWtZpNPaXmjiNDUe5CJuUtbkMrIM1kb1T/jJoAIp+bkVP/r5lHzMr+ZAAF8XHp7+my6Ol0ysQ==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.3.tgz",
+      "integrity": "sha512-oN88zz7nmKROMy8GOjs+LN+0LedIvbMdnB5XsTlhcOg1WGARt9l0LFg0zohdoFmCsEZ1h2ZbSQ6azj3M+vhzwQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -8716,9 +8740,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -9451,9 +9475,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -18606,15 +18630,15 @@
       }
     },
     "node_modules/react-error-overlay": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-      "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "node_modules/react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "peer": true
     },
     "node_modules/react-refresh": {
@@ -25200,12 +25224,13 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
@@ -27507,10 +27532,26 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
       "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -28062,9 +28103,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.0.tgz",
-      "integrity": "sha512-r8aveDbd+rzGP+ykSdF3oPuTVRWRfbBiHl0rVDM2yNEmSMXfkObQLV46b4RnCv3Lra51OlfnZhkkFaDl2MIRaA==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -28200,9 +28241,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.49.tgz",
-      "integrity": "sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==",
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -30724,18 +30765,18 @@
       }
     },
     "core-js": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.2.tgz",
-      "integrity": "sha512-Z5I2vzDnEIqO2YhELVMFcL1An2CIsFe9Q7byZhs8c/QxummxZlAHw33TUHbIte987LkisOgL0LwQ1P9D6VISnA==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.3.tgz",
+      "integrity": "sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-      "integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+      "integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.20.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -30748,9 +30789,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.2.tgz",
-      "integrity": "sha512-Lb+/XT4WC4PaCWWtZpNPaXmjiNDUe5CJuUtbkMrIM1kb1T/jJoAIp+bkVP/r5lHzMr+ZAAF8XHp7+my6Ol0ysQ==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.3.tgz",
+      "integrity": "sha512-oN88zz7nmKROMy8GOjs+LN+0LedIvbMdnB5XsTlhcOg1WGARt9l0LFg0zohdoFmCsEZ1h2ZbSQ6azj3M+vhzwQ==",
       "dev": true
     },
     "core-util-is": {
@@ -31831,9 +31872,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "elliptic": {
@@ -32444,9 +32485,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "requires": {}
     },
@@ -39730,15 +39771,15 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-      "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "peer": true
     },
     "react-refresh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reach-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reach-react",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@jackcom/raphsducks": "^1.1.6",
         "@jackcom/reachduck": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reach-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "dependencies": {
     "@jackcom/raphsducks": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "pre-commit": "^1.2.2",
     "prettier": "^2.5.1",
+    "react-error-overlay": "6.0.9",
     "react-scripts": "4.0.3",
     "sass": "^1.39.2",
     "typescript": "^4.4.3"

--- a/src/reach/index.ts
+++ b/src/reach/index.ts
@@ -10,7 +10,7 @@ import {
   disconnectUser,
   tokenMetadata as getReachToken,
   optInToAsset,
-  loadReachWithOpts
+  loadReachWithOpts,
 } from "@jackcom/reachduck";
 import { ReachAccount, ReachToken } from "@jackcom/reachduck/lib/types";
 import {
@@ -30,9 +30,7 @@ export async function connect(provider: string) {
 /** Reconnect user session */
 export async function reconnect() {
   const { addr = undefined, isWCSession } = checkSessionExists();
-  configureWalletProvider(
-      isWCSession ? "WalletConnect" : "MyAlgo"
-  );
+  configureWalletProvider(isWCSession ? "WalletConnect" : "MyAlgo");
   const updates = await reconnectUser(addr);
   store.multiple(updates);
   return updates.account;
@@ -55,7 +53,7 @@ export async function inlineAssetOptIn(
 
   const [asset, accepted] = await Promise.all([
     tokenMetadata(tokenId, acc),
-    optInToAsset(acc, tokenId)
+    optInToAsset(acc, tokenId),
   ]);
 
   if (accepted) {
@@ -89,9 +87,11 @@ export async function checkHasToken(token: any) {
 /** Initialize the `stdlib` instance according to the wallet provider. */
 function configureWalletProvider(pr: string) {
   if (!["WalletConnect", "MyAlgo"].includes(pr)) return;
+
+  const fallback = pr === "MyAlgo" ? { MyAlgoConnect } : { WalletConnect };
+
   loadReachWithOpts(loadStdlib, {
-    walletFallback:
-        pr === "MyAlgo" ? { MyAlgoConnect } : { WalletConnect },
+    walletFallback: fallback,
     network: "TestNet",
   });
 }


### PR DESCRIPTION
* Locks `react-error-overlay` to `v6.0.9` as recommended [here](https://stackoverflow.com/a/70452191/2291968)
